### PR TITLE
Rename draft to reflect cose WG adoption

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Automatically generated CODEOWNERS
 # Regenerate with `make update-codeowners`
-draft-looker-cose-bls-key-representations.md tobias.looker@mattr.global
+draft-ietf-cose-bls-key-representations.md tobias.looker@mattr.global

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 .targets.mk
 /*-[0-9][0-9].xml
 archive.json
-draft-looker-cose-bls-key-representations.xml
+draft-ietf-cose-bls-key-representations.xml
 lib
 report.xml
 venv/

--- a/.note.xml
+++ b/.note.xml
@@ -1,4 +1,4 @@
 <note title="Discussion Venues" removeInRFC="true">
 <t>Source for this draft and an issue tracker can be found at
-    <eref target="https://github.com/tplooker/draft-looker-cose-bls-key-representations"/>.</t>
+    <eref target="https://github.com/tplooker/draft-ietf-cose-bls-key-representations"/>.</t>
 </note>

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
 # License
 
 See the
-[guidelines for contributions](https://github.com/tplooker/draft-looker-cose-bls-key-representations/blob/main/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/tplooker/draft-ietf-cose-bls-key-representations/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 This is the working area for the individual Internet-Draft, "Barreto-Lynn-Scott Elliptic Curve Key Representations for JOSE and COSE".
 
-* [Editor's Copy](https://tplooker.github.io/draft-looker-cose-bls-key-representations/#go.draft-looker-cose-bls-key-representations.html)
-* [Datatracker Page](https://datatracker.ietf.org/doc/draft-looker-cose-bls-key-representations)
-* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-looker-cose-bls-key-representations)
-* [Compare Editor's Copy to Individual Draft](https://tplooker.github.io/draft-looker-cose-bls-key-representations#go.draft-looker-cose-bls-key-representations.diff)
+* [Editor's Copy](https://tplooker.github.io/draft-ietf-cose-bls-key-representations/#go.draft-ietf-cose-bls-key-representations.html)
+* [Datatracker Page](https://datatracker.ietf.org/doc/draft-ietf-cose-bls-key-representations)
+* [Individual Draft](https://datatracker.ietf.org/doc/html/draft-ietf-cose-bls-key-representations)
+* [Compare Editor's Copy to Individual Draft](https://tplooker.github.io/draft-ietf-cose-bls-key-representations#go.draft-ietf-cose-bls-key-representations.diff)
 
 
 ## Contributing
 
 See the
-[guidelines for contributions](https://github.com/tplooker/draft-looker-cose-bls-key-representations/blob/main/CONTRIBUTING.md).
+[guidelines for contributions](https://github.com/tplooker/draft-ietf-cose-bls-key-representations/blob/main/CONTRIBUTING.md).
 
 Contributions can be made by creating pull requests.
 The GitHub interface supports creating pull requests using the Edit (✏) button.

--- a/draft-looker-cose-bls-key-representations.md
+++ b/draft-looker-cose-bls-key-representations.md
@@ -8,7 +8,7 @@ keyword = ["COSE", "JOSE"]
 
 [seriesInfo]
 name = "Internet-Draft"
-value = "draft-looker-cose-bls-key-representations-latest"
+value = "draft-ietf-cose-bls-key-representations-latest"
 status = "standard"
 
 [pi]

--- a/draft-looker-cose-bls-key-representations.md
+++ b/draft-looker-cose-bls-key-representations.md
@@ -208,7 +208,7 @@ The authors would like to acknowledge the work of Kyle Den Hartog, which was use
 
 -00
 
-* Initial version
+* Created draft-ietf-cose-bls-key-representations-00 from draft-looker-cose-bls-key-representations-00 following working group adoption.
 
 <reference anchor="IANA.COSE.Curves" target="https://www.iana.org/assignments/cose/cose.xhtml#elliptic-curves">
  <front>


### PR DESCRIPTION
As per the title following the formal adoption by the COSE WG this PR updates the draft name to reflect this.