### PR TITLE
Use actions/cache@v4 and actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -28,6 +28,6 @@ jobs:
         token: ${{ github.token }}
 
     - name: "Save Archive"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: archive.json

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -30,7 +30,7 @@ jobs:
         date -u "+::set-output name=date::%FT%T"
 
     - name: "Cache References"
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.cache-setup.outputs.path }}
@@ -53,7 +53,7 @@ jobs:
         token: ${{ github.token }}
 
     - name: "Archive Built Drafts"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: |
           draft-*.html

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
         date -u "+::set-output name=date::%FT%T"
 
     - name: "Cache References"
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ${{ steps.cache-setup.outputs.path }}
@@ -46,6 +46,6 @@ jobs:
         make: upload
 
     - name: "Archive Submitted Drafts"
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         path: "draft-*-[0-9][0-9].xml"


### PR DESCRIPTION
Stop builds from failing due to deprecated GitHub actions