### PR TITLE
Define BLS48-581 encoding, update other sections to match

### DIFF
--- a/draft-ietf-cose-bls-key-representations.md
+++ b/draft-ietf-cose-bls-key-representations.md
@@ -61,7 +61,9 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Point Coordinates Encoding
 
-A point representing a public key will either be in the G1 or G2 subgroup of a curve. Depending on which one of the subgroups the public key will belong to, different serialization procedures need to be used, to encode its coordinates. Most specifically, if the public key is a point in the G1 subgroup, each of its coordinates MUST be encoded using the serialization defined in Section 2.3.5 of [@SEC1]. If the public key is a point in the G2 subgroup, each of its coordinates MUST be serialize using the procedure described in Appendix I.5 in [@I-D.ietf-lwig-curve-representations].
+A point representing a public key will either be in the G1 or G2 subgroup of a curve. Both are encoded using the compressed serialized point format defined normatively in Appendix B.2 of [@BBS].
+<!-- A syntax like this is supposed to work for making a section reference, but I can't get it to work here for some reason: `[@BBS, section B.2]` -->
+
 
 ## Representation Definition
 
@@ -89,10 +91,10 @@ When expressing a cryptographic key for these curves in COSE_Key form, the follo
 
 JWK "crv" value | COSE_Key "crv" value | Description         |
 ----------------|----------------------|---------------------|
-BLS12381G1      | TBD (13 requested)                   | A cryptographic key on the Barreto-Lynn-Scott (BLS) curve featuring an embedding degree 12 with 381-bit p in the subgroup of G1 defined as `E(GF(p))` of order r. The private key will be 32 bytes long. Each of the x and y coordinates of the public key will be 48 bytes long.
-BLS12381G2      | TBD (14 requested)                   | A cryptographic key on the Barreto-Lynn-Scott (BLS) curve featuring an embedding degree 12 with 381-bit p in the subgroup of G2 defined as `E(GF(p^2))` of order r. The private key will be 32 bytes long. Each of the x and y coordinates of the public key will be 96 bytes long.
-BLS48581G1      | TBD (15 requested)                   | A cryptographic key on the Barreto-Lynn-Scott (BLS) curve featuring an embedding degree 48 with 581-bit p in the subgroup of G1 defined as `E(GF(p))` of order r. The private key will be 65 bytes long. Each of the x and y coordinates of the public key will be 73 bytes long.
-BLS48581G2      | TBD (16 requested)                   | A cryptographic key on the Barreto-Lynn-Scott (BLS) curve featuring an embedding degree 48 with 581-bit p in the subgroup of G2 defined as `E(GF(p^8))` of order r. The private key will be 65 bytes long. Each of the x and y coordinates of the public key will be 584 bytes long.
+BLS12381G1      | TBD (13 requested)                   | A cryptographic key on the Barreto-Lynn-Scott (BLS) curve featuring an embedding degree 12 with 381-bit p in the subgroup of G1 defined as `E(GF(p))` of order r. The private key will be 32 bytes long. The public key will be 48 bytes long.
+BLS12381G2      | TBD (14 requested)                   | A cryptographic key on the Barreto-Lynn-Scott (BLS) curve featuring an embedding degree 12 with 381-bit p in the subgroup of G2 defined as `E(GF(p^2))` of order r. The private key will be 32 bytes long. The public key will be 96 bytes long.
+BLS48581G1      | TBD (15 requested)                   | A cryptographic key on the Barreto-Lynn-Scott (BLS) curve featuring an embedding degree 48 with 581-bit p in the subgroup of G1 defined as `E(GF(p))` of order r. The private key will be 65 bytes long. The public key will be 73 bytes long.
+BLS48581G2      | TBD (16 requested)                   | A cryptographic key on the Barreto-Lynn-Scott (BLS) curve featuring an embedding degree 48 with 581-bit p in the subgroup of G2 defined as `E(GF(p^8))` of order r. The private key will be 65 bytes long. The public key will be 584 bytes long.
 
 # Security Considerations
 

--- a/draft-ietf-cose-bls-key-representations.md
+++ b/draft-ietf-cose-bls-key-representations.md
@@ -73,7 +73,7 @@ When expressing a cryptographic key for these curves in JSON Web Key (JWK) form,
 
 - The parameter "kty" MUST be present and set to "OKP".
 - The parameter "crv" MUST be present and value MUST be one defined in (#curve-parameter-registration).
-- The parameter "x" MUST be present with its value being the base64url encoding of the compressed serialized point format defined normatively in Appendix B of <xref target="BBS"/>.
+- The parameter "x" MUST be present with its value being the base64url encoding of the compressed serialized point format defined normatively in Appendix B of [@BBS].
 - The parameter "d" MUST be present for private key representations whose value MUST contain the big-endian representation of the private key base64url encoded without padding as defined in [@!RFC7515] Appendix C. This parameter MUST NOT be present for public keys.
 
 ### COSE_Key Representation
@@ -82,7 +82,7 @@ When expressing a cryptographic key for these curves in COSE_Key form, the follo
 
 - The parameter "kty" (1) MUST be present and set to "OKP" (1).
 - The parameter "crv" (-1) MUST be present and value MUST be one defined in (#curve-parameter-registration).
-- The parameter "x" (-2) MUST be present with its value being the compressed serialized point format defined normatively in Appendix B of <xref target="BBS"/>.
+- The parameter "x" (-2) MUST be present with its value being the compressed serialized point format defined normatively in Appendix B of [@BBS].
 - The parameter "d" (-4) MUST be present for private key representations whose value MUST contain the big-endian representation of the private key. This parameter MUST NOT be present for public keys.
 
 ### Curve Parameter Registration
@@ -635,7 +635,7 @@ for their contributions to the specification.
 
 -08
 
-* Use ZCash compressed point format defined normatively in Appendix B of <xref target="BBS"/>.
+* Use ZCash compressed point format defined normatively in Appendix B of [@BBS].
 * Use "kty": "OKP" instead of "EC"/"EC2".
 * Added Emil Lundberg to the acknowledgements.
 


### PR DESCRIPTION
(This is a meta-PR into https://github.com/tplooker/draft-ietf-cose-bls-key-representations/pull/31)

- Fix some references using `<xref>` syntax instead of `[@REF]`
- Fix sections 2.1 and 2.2.3 referring to distinct `x` and `y` attributes
- Define analogous encoding for BLS48-581, since draft-irtf-cfrg-bbs-signatures-09 only defines it for BLS12-381