### PR TITLE
Require fixed-length private key

### DIFF
--- a/draft-ietf-cose-bls-key-representations.md
+++ b/draft-ietf-cose-bls-key-representations.md
@@ -74,7 +74,7 @@ When expressing a cryptographic key for these curves in JSON Web Key (JWK) form,
 - The parameter "kty" MUST be present and set to "OKP".
 - The parameter "crv" MUST be present and value MUST be one defined in (#curve-parameter-registration).
 - The parameter "x" MUST be present with its value being the base64url encoding of the compressed serialized point format defined normatively in Appendix B of <xref target="BBS"/>.
-- The parameter "d" MUST be present for private key representations whose value MUST contain the big-endian representation of the private key base64url encoded without padding as defined in [@!RFC7515] Appendix C. This parameter MUST NOT be present for public keys.
+- The parameter "d" MUST be present for private key representations whose value MUST contain the big-endian representation of the private key base64url encoded without padding as defined in [@!RFC7515] Appendix C. The length of this octet string MUST be `ceiling(log-base-2(n)/8)` octets (where `n` is the order of the curve). This parameter MUST NOT be present for public keys.
 
 ### COSE_Key Representation
 
@@ -83,7 +83,7 @@ When expressing a cryptographic key for these curves in COSE_Key form, the follo
 - The parameter "kty" (1) MUST be present and set to "OKP" (1).
 - The parameter "crv" (-1) MUST be present and value MUST be one defined in (#curve-parameter-registration).
 - The parameter "x" (-2) MUST be present with its value being the compressed serialized point format defined normatively in Appendix B of <xref target="BBS"/>.
-- The parameter "d" (-4) MUST be present for private key representations whose value MUST contain the big-endian representation of the private key. This parameter MUST NOT be present for public keys.
+- The parameter "d" (-4) MUST be present for private key representations whose value MUST contain the big-endian representation of the private key. The length of this octet string MUST be `ceiling(log-base-2(n)/8)` octets (where `n` is the order of the curve). This parameter MUST NOT be present for public keys.
 
 ### Curve Parameter Registration
 


### PR DESCRIPTION
(This is a meta-PR into https://github.com/tplooker/draft-ietf-cose-bls-key-representations/pull/31)

Per https://github.com/tplooker/draft-ietf-cose-bls-key-representations/pull/31#discussion_r2486561125

This has precedent in RFC 7518, section 6.2.2.1:
https://www.rfc-editor.org/rfc/rfc7518.html#section-6.2.2.1

And also indirectly in RFC 8037:
https://www.rfc-editor.org/rfc/rfc8037.html#section-2 since it implicitly delegates the private key encoding to RFC 8032 which also uses a fixed-length encoding: https://www.rfc-editor.org/rfc/rfc8032#section-3.1